### PR TITLE
Upgrade ghostSource url to take ghost latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # About
 
-A script to help automate upgrading Ghost (https://ghost.org/). This script backs up content/themes and content/images. It does not back up your database or dump the json (yet). The script will download and extract the ghost archive.
+A script to help automate upgrading Ghost (https://ghost.org/). This script
+backs up content/themes and content/images. It does not back up your database
+or dump the json (yet). The script will download and extract the ghost archive.
 
-#Requirements
-This script requires wget. If you are on OS X and have homebrew installed then you can run "brew install wget". If you do not have homebrew installed then follow these instructions: http://osxdaily.com/2012/05/22/install-wget-mac-os-x/
+# Requirements
+This script requires wget. If you are on OS X and have homebrew installed then
+you can run "brew install wget". If you do not have homebrew installed then
+follow these instructions:
+http://osxdaily.com/2012/05/22/install-wget-mac-os-x/
 
-#Usage
+# Usage
 
 1. Download the script.
-2. Update directory variables to match your install, backup, ghost zip url, and temp locations. The temp directory is removed upon completion.
+2. Update directory variables to match your install, backup, ghost zip url, and
+   temp locations. The temp directory is removed upon completion.
 3. Make sure the script is executable
 4. Execute the script.
 5. Start Ghost.

--- a/upgradeghost.sh
+++ b/upgradeghost.sh
@@ -1,17 +1,17 @@
 #/bin/bash
 ############################
 # updgradeghost.sh
-# This script creates a backup of ghost directories and then performs an upgrade 
+# This script creates a backup of ghost directories and then performs an upgrade
 ############################
 
 ghostDir=~/Documents/PersonalProjects/portfolio-site-ghost-theme/   #working ghost install
 ghostBackupDir=~/Documents/PersonalProjects/backup-portfolio-site-ghost-theme/             # backup directory
 ghostTemp=~/ghostTemp/ #temp directory used to download and extract ghost then removed.
-ghostSource=https://ghost.org/zip/ghost-0.4.0.zip
+ghostSource=https://ghost.org/zip/ghost-latest.zip
 
 timeStamp=$(date +"%Y%m%d%H%M")
 
-# create backup directory 
+# create backup directory
 echo "Creating $ghostBackupDir$timeStamp for backup of any existing files in $ghostDir"
 mkdir -p $ghostBackupDir$timeStamp
 echo "...done"
@@ -21,7 +21,7 @@ echo "Changing to the $ghostDir directory"
 cd $ghostDir
 echo "...done"
 
-# copy any existing themes to backup 
+# copy any existing themes to backup
 echo "Backing up any themes from content/themes to $ghostBackupDir$timeStamp"
 cp -r content/themes $ghostBackupDir$timeStamp
 
@@ -36,7 +36,7 @@ cd $ghostTemp
 wget $ghostSource
 echo "...done"
 echo "Extracting ghost "
-unzip "*.zip" 
+unzip "*.zip"
 echo "...done"
 
 #copy new files into existing install


### PR DESCRIPTION
I think it is better to use default latest link for an upgrade script. I also removed trailing spaces.

Thanks for your awesome work! Your script is still working